### PR TITLE
Explicit int casting

### DIFF
--- a/src/NavOnlineInvoice/BaseRequestXml.php
+++ b/src/NavOnlineInvoice/BaseRequestXml.php
@@ -54,7 +54,7 @@ abstract class BaseRequestXml {
         $milliseconds = round(($now - floor($now)) * 1000);
         $milliseconds = min($milliseconds, 999);
 
-        return gmdate("Y-m-d\TH:i:s", $now) . sprintf(".%03dZ", $milliseconds);
+        return gmdate("Y-m-d\TH:i:s", (int) $now) . sprintf(".%03dZ", $milliseconds);
     }
 
 


### PR DESCRIPTION
Avoid the php 8.1 deprecation

Deprecated: Implicit conversion from float 1643214619.570649 to int loses precision in /var/www/html/vendor/pzs/nav-online-invoice/src/NavOnlineInvoice/BaseRequestXml.php on line 57